### PR TITLE
Change open() parameters in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 try:
-    with open('README.md') as fh:
+    with open('README.md', 'rt', encoding='UTF8') as fh:
         long_description = fh.read()
 except IOError as e:
     long_description = ""


### PR DESCRIPTION
When using pip3 install --user occurs decoding error 'cp949'.

So change to open() parameters by adding 'rt' and encoding='UTF8'