### PR TITLE
Unittest 버전체크, 개념글 API추가, README 업데이트, 기타

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ import dc_api
 
 api = dc_api.API()
 
-async for index in api.board(board_id="programming", num=-1, start_page=1, doc_id_upper_limit=None, doc_id_lower_limit=None):
+async for index in api.board(board_id="programming", num=-1, start_page=1, document_id_upper_limit=None, document_id_lower_limit=None):
     index.id         # => 835027
     index.board_id   # => programming
     index.title      # => "땔감 벗어나는법.tip"

--- a/dc_api.py
+++ b/dc_api.py
@@ -58,8 +58,8 @@ def peek(iterable):
     return first, itertools.chain((first,), iterable)
 
 class DocumentIndex:
-    __slots__ = ["id", "subject", "title", "board_id", "has_image", "author", "time", "view_count", "comment_count", "voteup_count", "document", "comments"]
-    def __init__(self, id, board_id, title, has_image, author, time, view_count, comment_count, voteup_count, document, comments, subject):
+    __slots__ = ["id", "subject", "title", "board_id", "has_image", "author", "time", "view_count", "comment_count", "voteup_count", "document", "comments", "image_available"]
+    def __init__(self, id, board_id, title, has_image, author, time, view_count, comment_count, voteup_count, document, comments, subject, image_available):
         self.id = id
         self.board_id = board_id
         self.title = title
@@ -72,6 +72,7 @@ class DocumentIndex:
         self.document = document
         self.comments = comments
         self.subject = subject
+        self.image_available = image_available
     def __str__(self):
         return f"{self.subject or ''}\t|{self.id}\t|{self.time.isoformat()}\t|{self.author}\t|{self.title}({self.comment_count}) +{self.voteup_count}"
 
@@ -188,6 +189,10 @@ class API:
                     time= self.__parse_time(doc[0][1][1].text)
                     view_count= int(doc[0][1][2].text.split()[-1])
                     voteup_count= int(doc[0][1][3].text_content().split()[-1])
+                if "sp-lst-img" in doc[0][0][0].get("class"):
+                    image_available = True
+                else:
+                    image_available = False
                 title = doc[0][0][1].text
                 indexdata = DocumentIndex(
                     id= document_id,
@@ -201,7 +206,8 @@ class API:
                     document= lambda: self.document(board_id, document_id),
                     comments= lambda: self.comments(board_id, document_id),
                     time= time,
-                    subject=subject
+                    subject=subject,
+                    image_available=image_available
                     )
                 yield(indexdata)
                 num-=1

--- a/dc_api.py
+++ b/dc_api.py
@@ -144,6 +144,22 @@ class API:
         await self.close()
     async def watch(self, board_id):
         pass
+    async def gallery(self, name=None):
+        url = "https://m.dcinside.com/galltotal"
+        gallerys={}
+        async with self.session.get(url) as res:
+            text = await res.text()
+            parsed = lxml.html.fromstring(text)
+        for i in range(1, len(parsed.xpath('//*[@id="total_1"]/li'))+1):
+            link = parsed.xpath('//*[@id="total_1"]/li[' + str(i) + "]/a")[0]
+            board_name = parsed.xpath('//*[@id="total_1"]/li[' + str(i) + "]")[0].text_content().strip()
+            board_id = link.get("href").split("/")[-1] 
+            if name:
+                if name in board_name:
+                    gallerys[board_name] = board_id
+            else:
+                gallerys[board_name] = board_id
+        return gallerys
     async def board(self, board_id, num=-1, start_page=1, recommend=False, document_id_upper_limit=None, document_id_lower_limit=None, is_minor=False):
         page = start_page
         while num:

--- a/dc_api.py
+++ b/dc_api.py
@@ -150,15 +150,16 @@ class API:
         async with self.session.get(url) as res:
             text = await res.text()
             parsed = lxml.html.fromstring(text)
-        for i in range(1, len(parsed.xpath('//*[@id="total_1"]/li'))+1):
-            link = parsed.xpath('//*[@id="total_1"]/li[' + str(i) + "]/a")[0]
-            board_name = parsed.xpath('//*[@id="total_1"]/li[' + str(i) + "]")[0].text_content().strip()
-            board_id = link.get("href").split("/")[-1] 
-            if name:
-                if name in board_name:
-                    gallerys[board_name] = board_id
-            else:
-                gallerys[board_name] = board_id
+        for i in parsed.xpath('//*[@id="total_1"]/li'):
+            for e in i.iter():
+                if e.tag == "a":
+                    board_name = e.text
+                    board_id = e.get("href").split("/")[-1]
+                    if name:
+                        if name in board_name:
+                            gallerys[board_name] = board_id
+                    else:
+                        gallerys[board_name] = board_id
         return gallerys
     async def board(self, board_id, num=-1, start_page=1, recommend=False, document_id_upper_limit=None, document_id_lower_limit=None, is_minor=False):
         page = start_page

--- a/dc_api.py
+++ b/dc_api.py
@@ -144,10 +144,13 @@ class API:
         await self.close()
     async def watch(self, board_id):
         pass
-    async def board(self, board_id, num=-1, start_page=1, document_id_upper_limit=None, document_id_lower_limit=None, is_minor=False):
+    async def board(self, board_id, num=-1, start_page=1, recommend=False, document_id_upper_limit=None, document_id_lower_limit=None, is_minor=False):
         page = start_page
         while num:
-            url = "https://m.dcinside.com/board/{}?page={}".format(board_id, page)
+            if recommend:
+                url = "https://m.dcinside.com/board/{}?recommend=1&page={}".format(board_id, page)
+            else:
+                url = "https://m.dcinside.com/board/{}?page={}".format(board_id, page)
             async with self.session.get(url) as res:
                 text = await res.text()
                 parsed = lxml.html.fromstring(text)

--- a/dc_api.py
+++ b/dc_api.py
@@ -529,139 +529,143 @@ class API:
                 return datetime.strptime(time, "%Y-%m-%d %H:%M:%S")
 
 import unittest
+import sys
 
-class Test(unittest.IsolatedAsyncioTestCase):
-    def setUp(self):
-        pass
-    async def asyncSetUp(self):
-        self.api = API()
-    async def asyncTearDown(self):
-        await self.api.close()
-    async def test_async_with(self):
-        async with API() as api:
-            doc = api.board(board_id='aoegame', num=1).__anext__()
+# Check version info
+version = sys.version_info
+if version.major >= 3 and version.minor >= 8:
+    class Test(unittest.IsolatedAsyncioTestCase):
+        def setUp(self):
+            pass
+        async def asyncSetUp(self):
+            self.api = API()
+        async def asyncTearDown(self):
+            await self.api.close()
+        async def test_async_with(self):
+            async with API() as api:
+                doc = api.board(board_id='aoegame', num=1).__anext__()
+                self.assertNotEqual(doc, None)
+        async def test_read_minor_board_one(self):
+            async for doc in self.api.board(board_id='aoegame', num=1):
+                for attr in doc.__slots__:
+                    if attr == 'subject': continue
+                    val = getattr(doc, attr)
+                    self.assertNotEqual(val, None, attr)
+                    self.assertNotEqual(val, '', attr)
+                self.assertGreater(doc.time, datetime.now() - timedelta(hours=1))
+                self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
+        async def test_read_minor_board_many(self):
+            count = 0
+            async for doc in self.api.board(board_id='aoegame', num=201):
+                for attr in doc.__slots__:
+                    if attr == 'subject': continue
+                    val = getattr(doc, attr)
+                    self.assertNotEqual(val, None, attr)
+                    self.assertNotEqual(val, '', attr)
+                count += 1
+                self.assertGreater(doc.time, datetime.now() - timedelta(hours=1))
+                self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
+            self.assertAlmostEqual(count, 201)
+        async def test_read_minor_recent_comments(self):
+            async for doc in self.api.board(board_id='aoegame'):
+                comments = [comm async for comm in doc.comments()]
+                if not comments: continue
+                for comm in comments:
+                    for attr in comm.__slots__:
+                        if attr in ['contents', 'dccon', 'voice', 'author_id']: continue
+                        val = getattr(comm, attr)
+                        self.assertNotEqual(val, None, attr)
+                        self.assertNotEqual(val, '', attr)
+                    self.assertNotEqual(comm.contents or comm.dccon or comm.voice, None)
+                    self.assertGreater(comm.time, datetime.now() - timedelta(hours=1))
+                    self.assertLess(comm.time, datetime.now() + timedelta(hours=1))
+                break
+        async def test_read_board_one(self):
+            async for doc in self.api.board(board_id='programming', num=1):
+                for attr in doc.__slots__:
+                    if attr == 'subject': continue
+                    val = getattr(doc, attr)
+                    self.assertNotEqual(val, None, attr)
+                    self.assertNotEqual(val, '', attr)
+                self.assertGreater(doc.time, datetime.now() - timedelta(hours=24))
+                self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
+        async def test_read_board_many(self):
+            count = 0
+            async for doc in self.api.board(board_id='programming', num=201):
+                for attr in doc.__slots__:
+                    if attr == 'subject': continue
+                    val = getattr(doc, attr)
+                    self.assertNotEqual(val, None, attr)
+                    self.assertNotEqual(val, '', attr)
+                count += 1
+                self.assertGreater(doc.time, datetime.now() - timedelta(hours=24))
+                self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
+            self.assertAlmostEqual(count, 201)
+        async def test_read_recent_comments(self):
+            async for doc in self.api.board(board_id='aoegame'):
+                comments = [comm async for comm in doc.comments()]
+                if not comments: continue
+                for comm in comments:
+                    for attr in comm.__slots__:
+                        if attr in ['contents', 'dccon', 'voice', 'author_id']: continue
+                        val = getattr(comm, attr)
+                        self.assertNotEqual(val, None, attr)
+                        self.assertNotEqual(val, '', attr)
+                    self.assertNotEqual(comm.contents or comm.dccon or comm.voice, None)
+                    self.assertGreater(comm.time, datetime.now() - timedelta(hours=24))
+                    self.assertLess(comm.time, datetime.now() + timedelta(hours=1))
+                break
+        async def test_minor_document(self):
+            doc = await (await self.api.board(board_id='aoegame', num=1).__anext__()).document()
             self.assertNotEqual(doc, None)
-    async def test_read_minor_board_one(self):
-        async for doc in self.api.board(board_id='aoegame', num=1):
             for attr in doc.__slots__:
-                if attr == 'subject': continue
+                if attr in ['author_id', 'subject']: continue
                 val = getattr(doc, attr)
                 self.assertNotEqual(val, None, attr)
                 self.assertNotEqual(val, '', attr)
             self.assertGreater(doc.time, datetime.now() - timedelta(hours=1))
             self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
-    async def test_read_minor_board_many(self):
-        count = 0
-        async for doc in self.api.board(board_id='aoegame', num=201):
+        async def test_document(self):
+            doc = await (await self.api.board(board_id='programming', num=1).__anext__()).document()
+            self.assertNotEqual(doc, None)
             for attr in doc.__slots__:
-                if attr == 'subject': continue
+                if attr in ['author_id', 'subject']: continue
                 val = getattr(doc, attr)
                 self.assertNotEqual(val, None, attr)
-                self.assertNotEqual(val, '', attr)
-            count += 1
             self.assertGreater(doc.time, datetime.now() - timedelta(hours=1))
             self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
-        self.assertAlmostEqual(count, 201)
-    async def test_read_minor_recent_comments(self):
-        async for doc in self.api.board(board_id='aoegame'):
-            comments = [comm async for comm in doc.comments()]
-            if not comments: continue
-            for comm in comments:
-                for attr in comm.__slots__:
-                    if attr in ['contents', 'dccon', 'voice', 'author_id']: continue
-                    val = getattr(comm, attr)
-                    self.assertNotEqual(val, None, attr)
-                    self.assertNotEqual(val, '', attr)
-                self.assertNotEqual(comm.contents or comm.dccon or comm.voice, None)
-                self.assertGreater(comm.time, datetime.now() - timedelta(hours=1))
-                self.assertLess(comm.time, datetime.now() + timedelta(hours=1))
-            break
-    async def test_read_board_one(self):
-        async for doc in self.api.board(board_id='programming', num=1):
-            for attr in doc.__slots__:
-                if attr == 'subject': continue
-                val = getattr(doc, attr)
-                self.assertNotEqual(val, None, attr)
-                self.assertNotEqual(val, '', attr)
-            self.assertGreater(doc.time, datetime.now() - timedelta(hours=24))
-            self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
-    async def test_read_board_many(self):
-        count = 0
-        async for doc in self.api.board(board_id='programming', num=201):
-            for attr in doc.__slots__:
-                if attr == 'subject': continue
-                val = getattr(doc, attr)
-                self.assertNotEqual(val, None, attr)
-                self.assertNotEqual(val, '', attr)
-            count += 1
-            self.assertGreater(doc.time, datetime.now() - timedelta(hours=24))
-            self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
-        self.assertAlmostEqual(count, 201)
-    async def test_read_recent_comments(self):
-        async for doc in self.api.board(board_id='aoegame'):
-            comments = [comm async for comm in doc.comments()]
-            if not comments: continue
-            for comm in comments:
-                for attr in comm.__slots__:
-                    if attr in ['contents', 'dccon', 'voice', 'author_id']: continue
-                    val = getattr(comm, attr)
-                    self.assertNotEqual(val, None, attr)
-                    self.assertNotEqual(val, '', attr)
-                self.assertNotEqual(comm.contents or comm.dccon or comm.voice, None)
-                self.assertGreater(comm.time, datetime.now() - timedelta(hours=24))
-                self.assertLess(comm.time, datetime.now() + timedelta(hours=1))
-            break
-    async def test_minor_document(self):
-        doc = await (await self.api.board(board_id='aoegame', num=1).__anext__()).document()
-        self.assertNotEqual(doc, None)
-        for attr in doc.__slots__:
-            if attr in ['author_id', 'subject']: continue
-            val = getattr(doc, attr)
-            self.assertNotEqual(val, None, attr)
-            self.assertNotEqual(val, '', attr)
-        self.assertGreater(doc.time, datetime.now() - timedelta(hours=1))
-        self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
-    async def test_document(self):
-        doc = await (await self.api.board(board_id='programming', num=1).__anext__()).document()
-        self.assertNotEqual(doc, None)
-        for attr in doc.__slots__:
-            if attr in ['author_id', 'subject']: continue
-            val = getattr(doc, attr)
-            self.assertNotEqual(val, None, attr)
-        self.assertGreater(doc.time, datetime.now() - timedelta(hours=1))
-        self.assertLess(doc.time, datetime.now() + timedelta(hours=1))
-    '''
-    async def test_write_mod_del_document_comment(self):
-        board_id='programming'
-        doc_id = await self.api.write_document(board_id=board_id, title="제목", contents="내용", name="닉네임", password="비밀번호")
-        doc = await self.api.document(board_id=board_id, document_id=doc_id)
-        self.assertEqual(doc.contents, "내용")
-        doc_id = await self.api.modify_document(board_id=board_id, document_id=doc_id, title="수정된 제목", contents="수정된 내용", name="수정된 닉네임", password="비밀번호")
-        doc = await self.api.document(board_id=board_id, document_id=doc_id)
-        self.assertEqual(doc.contents, "수정된 내용")
-        comm_id = await self.api.write_comment(board_id=board_id, document_id=doc_id, contents="댓글", name="닉네임", password="비밀번호")
-        doc = await self.api.document(board_id=board_id, document_id=doc_id)
-        comm = await doc.comments().__anext__()
-        self.assertEqual(comm.contents, "댓글")
-        await self.api.remove_document(board_id=board_id, document_id=doc_id, password="비밀번호")
-        doc = await self.api.document(board_id=board_id, document_id=doc_id)
-        self.assertEqual(doc, None)
-    async def test_minor_write_mod_del_document_comment(self):
-        board_id='stick'
-        doc_id = await self.api.write_document(board_id=board_id, title="제목", contents="내용", name="닉네임", password="비밀번호", is_minor=True)
-        doc = await self.api.document(board_id=board_id, document_id=doc_id)
-        self.assertEqual(doc.contents, "내용")
-        doc_id = await self.api.modify_document(board_id=board_id, document_id=doc_id, title="수정된 제목", contents="수정된 내용", name="수정된 닉네임", password="비밀번호", is_minor=True)
-        doc = await self.api.document(board_id=board_id, document_id=doc_id)
-        self.assertEqual(doc.contents, "수정된 내용")
-        comm_id = await self.api.write_comment(board_id=board_id, document_id=doc_id, contents="댓글", name="닉네임", password="비밀번호")
-        doc = await self.api.document(board_id=board_id, document_id=doc_id)
-        comm = await doc.comments().__anext__()
-        self.assertEqual(comm.contents, "댓글")
-        await self.api.remove_document(board_id=board_id, document_id=doc_id, password="비밀번호")
-        doc = await self.api.document(board_id=board_id, document_id=doc_id)
-        self.assertEqual(doc, None)
-    '''
+        '''
+        async def test_write_mod_del_document_comment(self):
+            board_id='programming'
+            doc_id = await self.api.write_document(board_id=board_id, title="제목", contents="내용", name="닉네임", password="비밀번호")
+            doc = await self.api.document(board_id=board_id, document_id=doc_id)
+            self.assertEqual(doc.contents, "내용")
+            doc_id = await self.api.modify_document(board_id=board_id, document_id=doc_id, title="수정된 제목", contents="수정된 내용", name="수정된 닉네임", password="비밀번호")
+            doc = await self.api.document(board_id=board_id, document_id=doc_id)
+            self.assertEqual(doc.contents, "수정된 내용")
+            comm_id = await self.api.write_comment(board_id=board_id, document_id=doc_id, contents="댓글", name="닉네임", password="비밀번호")
+            doc = await self.api.document(board_id=board_id, document_id=doc_id)
+            comm = await doc.comments().__anext__()
+            self.assertEqual(comm.contents, "댓글")
+            await self.api.remove_document(board_id=board_id, document_id=doc_id, password="비밀번호")
+            doc = await self.api.document(board_id=board_id, document_id=doc_id)
+            self.assertEqual(doc, None)
+        async def test_minor_write_mod_del_document_comment(self):
+            board_id='stick'
+            doc_id = await self.api.write_document(board_id=board_id, title="제목", contents="내용", name="닉네임", password="비밀번호", is_minor=True)
+            doc = await self.api.document(board_id=board_id, document_id=doc_id)
+            self.assertEqual(doc.contents, "내용")
+            doc_id = await self.api.modify_document(board_id=board_id, document_id=doc_id, title="수정된 제목", contents="수정된 내용", name="수정된 닉네임", password="비밀번호", is_minor=True)
+            doc = await self.api.document(board_id=board_id, document_id=doc_id)
+            self.assertEqual(doc.contents, "수정된 내용")
+            comm_id = await self.api.write_comment(board_id=board_id, document_id=doc_id, contents="댓글", name="닉네임", password="비밀번호")
+            doc = await self.api.document(board_id=board_id, document_id=doc_id)
+            comm = await doc.comments().__anext__()
+            self.assertEqual(comm.contents, "댓글")
+            await self.api.remove_document(board_id=board_id, document_id=doc_id, password="비밀번호")
+            doc = await self.api.document(board_id=board_id, document_id=doc_id)
+            self.assertEqual(doc, None)
+        '''
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
1. Unittest 가 기본 dc_api.py 안에 있는데 버전 `3.8` 이상부터 정상적으로 작동이 가능하고, 실제 사용엔 전혀 쓸모가 없는 부분이라서 버전체크를 해서 Unittest를 진행하도록 바꿨습니다.

2. 개념글만 볼수있는 기능이 없는게 아쉬워서, 개념글을 볼수있도록 옵션을 하나 추가했습니다.
```
async def board(self, board_id, num=-1, start_page=1,
                      recommend=False, document_id_upper_limit=None, document_id_lower_limit=None, is_minor=False):

# 이제 recommend=True 면, 일반 게시글 대신 개념글을 가져옵니다.
```
단순히 GET 파라미터만 바꾸면 크롤링이 가능해서 간단히 추가해봤습니다

3. 실제 `dc_api.py` 에는 `document_id_upper_limit`, `document_id_lower_limit` 인데 README에는 다른 내용이 적혀져있어서 이를 업데이트 했습니다.

4. 갤러리 리스트를 가져오는 메소드를 구현했습니다. `gallery()`

5. board에서 돌려주는 리턴 변수 중에 이미지 존재여부를 추가했습니다. (개념글중 이미지존재, 동영상존재, 힛갤여부, 실북갤여부 등은 추후 추가예정입니다)